### PR TITLE
Feat/row clicks and custom edit redirect paths

### DIFF
--- a/app/[orgId]/contests/[id]/page.tsx
+++ b/app/[orgId]/contests/[id]/page.tsx
@@ -1,5 +1,5 @@
-import { ContestDetailPage } from "@/components/contest-details-table";
+// import { ContestDetailPage } from "@/components/contest-details-table";
 
 export default function ContestDetail() {
-  return <ContestDetailPage />;
+  return <div>Contest Detail</div>;
 }

--- a/app/[orgId]/contests/page.tsx
+++ b/app/[orgId]/contests/page.tsx
@@ -93,6 +93,7 @@ export default function ContestsPage() {
           setIsEditorOpen(true);
         }}
         onDelete={deleteContest}
+        rowClickAttr="nameId"
       />
 
       <GenericEditor

--- a/app/[orgId]/problems/page.tsx
+++ b/app/[orgId]/problems/page.tsx
@@ -111,12 +111,13 @@ export default function ProblemsPage({
         title="Problems"
         searchableFields={["nameId", "title"]}
         onAdd={handleAdd}
-        onEdit={handleEdit}
+        // onEdit={null}
         onDelete={handleDelete}
         allowDownload={true}
         addPage="new"
+        editPathAttr="id"
       />
-
+      {/*
       <Dialog open={isEditorOpen} onOpenChange={setIsEditorOpen}>
         <DialogContent className="max-w-4xl">
           <ProblemEditor
@@ -125,7 +126,7 @@ export default function ProblemsPage({
             onSave={handleSavelocal}
           />
         </DialogContent>
-      </Dialog>
+      </Dialog> */}
     </>
   );
 }

--- a/mint/generic-listing.tsx
+++ b/mint/generic-listing.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useMemo, useEffect } from "react";
 import { Input } from "@/components/ui/input";
 import {
@@ -27,6 +29,7 @@ import {
 } from "lucide-react";
 import { DeleteConfirmationModal } from "@/mint/delete-confirm";
 import { useToast } from "@/hooks/use-toast";
+import { useRouter } from "next/navigation";
 
 export interface ColumnDef<T> {
   header: string;
@@ -43,7 +46,8 @@ interface GenericListingProps<T> {
   onEdit?: (item: T) => void;
   onDelete?: (item: T) => Promise<void>;
   allowDownload?: boolean;
-  addPage?: string; // page to redirect to when user clicks add button
+  addPage?: string;
+  rowClickAttr?: keyof T; // attribute to use for navigation when row is clicked
 }
 
 // For passing to listing, the id should not be null, its just a temporary hack to satisfy typescript
@@ -57,7 +61,9 @@ export function GenericListing<T extends { id: number | undefined }>({
   onDelete,
   allowDownload = true,
   addPage,
+  rowClickAttr,
 }: GenericListingProps<T>) {
+  const router = useRouter();
   const [searchTerm, setSearchTerm] = useState("");
   const [sortField, setSortField] = useState<keyof T>(columns[0].accessorKey);
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
@@ -216,8 +222,20 @@ export function GenericListing<T extends { id: number | undefined }>({
             ) : (
               filteredAndSortedData.map((item) => (
                 <TableRow key={String(item.id)}>
-                  {columns.map((column) => (
-                    <TableCell key={String(column.accessorKey)}>
+                  {columns.map((column, index) => (
+                    <TableCell
+                      key={String(column.accessorKey)}
+                      className={
+                        index === 0 && rowClickAttr ? "hover:bg-muted/50" : ""
+                      }
+                      onClick={() => {
+                        if (index === 0 && rowClickAttr && item[rowClickAttr]) {
+                          router.push(
+                            `${window.location.pathname}/${String(item[rowClickAttr])}`,
+                          );
+                        }
+                      }}
+                    >
                       {String(item[column.accessorKey])}
                     </TableCell>
                   ))}

--- a/mint/generic-listing.tsx
+++ b/mint/generic-listing.tsx
@@ -48,6 +48,7 @@ interface GenericListingProps<T> {
   allowDownload?: boolean;
   addPage?: string;
   rowClickAttr?: keyof T; // attribute to use for navigation when row is clicked
+  editPathAttr?: keyof T; // attribute containing the edit path for navigation
 }
 
 // For passing to listing, the id should not be null, its just a temporary hack to satisfy typescript
@@ -62,6 +63,7 @@ export function GenericListing<T extends { id: number | undefined }>({
   allowDownload = true,
   addPage,
   rowClickAttr,
+  editPathAttr,
 }: GenericListingProps<T>) {
   const router = useRouter();
   const [searchTerm, setSearchTerm] = useState("");
@@ -206,14 +208,19 @@ export function GenericListing<T extends { id: number | undefined }>({
                   )}
                 </TableHead>
               ))}
-              {(onEdit || onDelete) && <TableHead>Actions</TableHead>}
+              {(onEdit || onDelete || editPathAttr) && (
+                <TableHead>Actions</TableHead>
+              )}
             </TableRow>
           </TableHeader>
           <TableBody>
             {filteredAndSortedData.length === 0 ? (
               <TableRow>
                 <TableCell
-                  colSpan={columns.length + (onEdit || onDelete ? 1 : 0)}
+                  colSpan={
+                    columns.length +
+                    (onEdit || onDelete || editPathAttr ? 1 : 0)
+                  }
                   className="h-24 text-center"
                 >
                   No results found.
@@ -239,7 +246,7 @@ export function GenericListing<T extends { id: number | undefined }>({
                       {String(item[column.accessorKey])}
                     </TableCell>
                   ))}
-                  {(onEdit || onDelete) && (
+                  {(onEdit || onDelete || editPathAttr) && (
                     <TableCell>
                       <DropdownMenu modal={false}>
                         <DropdownMenuTrigger asChild>
@@ -256,8 +263,18 @@ export function GenericListing<T extends { id: number | undefined }>({
                             <Copy className="mr-2 h-4 w-4" />
                             Copy ID
                           </DropdownMenuItem>
-                          {onEdit && (
-                            <DropdownMenuItem onClick={() => onEdit(item)}>
+                          {(onEdit || editPathAttr) && (
+                            <DropdownMenuItem
+                              onClick={() => {
+                                if (onEdit) {
+                                  onEdit(item);
+                                } else if (editPathAttr && item[editPathAttr]) {
+                                  router.push(
+                                    `${window.location.pathname}/${String(item[editPathAttr])}`,
+                                  );
+                                }
+                              }}
+                            >
                               <Pencil className="mr-2 h-4 w-4" />
                               Edit
                             </DropdownMenuItem>


### PR DESCRIPTION
This pull request includes several changes to the `app/[orgId]/contests/[id]/page.tsx`, `app/[orgId]/contests/page.tsx`, `app/[orgId]/problems/page.tsx`, and `mint/generic-listing.tsx` files. The changes primarily focus on modifying the contest and problem pages, and enhancing the generic listing component with new attributes for navigation.

Changes to contest and problem pages:

* `app/[orgId]/contests/[id]/page.tsx`: Commented out the import of `ContestDetailPage` and replaced its usage with a simple `div` element. ([app/[orgId]/contests/[id]/page.tsxL1-R4](diffhunk://#diff-6d3cbafb103a9652cd57a57aec6af9c179616d7a8333e7fb6280a1df72e79391L1-R4))
* `app/[orgId]/contests/page.tsx`: Added a `rowClickAttr` attribute to the contest listing component. ([app/[orgId]/contests/page.tsxR96](diffhunk://#diff-9e27059ea9687b5f6f60877610011cebdeb4dabe7a116e51a754765f4493d099R96))
* `app/[orgId]/problems/page.tsx`: Commented out the `onEdit` prop and added an `editPathAttr` attribute to the problem listing component. Also commented out the `Dialog` component used for editing problems. ([app/[orgId]/problems/page.tsxL114-R120](diffhunk://#diff-cfa1eeff685632ac2a9c7397ab5e5e1b8f7043da12aa66bb66214905b48e4f56L114-R120), [app/[orgId]/problems/page.tsxL128-R129](diffhunk://#diff-cfa1eeff685632ac2a9c7397ab5e5e1b8f7043da12aa66bb66214905b48e4f56L128-R129))

Enhancements to generic listing component:

* [`mint/generic-listing.tsx`](diffhunk://#diff-78dbe920496245969f82b2725fe53b5e08e545e8c7d1d2ad4f09a50d649cca7fL46-R51): Added `rowClickAttr` and `editPathAttr` attributes to the `GenericListingProps` interface and the `GenericListing` component. [[1]](diffhunk://#diff-78dbe920496245969f82b2725fe53b5e08e545e8c7d1d2ad4f09a50d649cca7fL46-R51) [[2]](diffhunk://#diff-78dbe920496245969f82b2725fe53b5e08e545e8c7d1d2ad4f09a50d649cca7fR65-R68)
* [`mint/generic-listing.tsx`](diffhunk://#diff-78dbe920496245969f82b2725fe53b5e08e545e8c7d1d2ad4f09a50d649cca7fL203-R223): Modified the table header and body to accommodate the new attributes, enabling row clicks for navigation and conditional rendering of the "Edit" action. [[1]](diffhunk://#diff-78dbe920496245969f82b2725fe53b5e08e545e8c7d1d2ad4f09a50d649cca7fL203-R223) [[2]](diffhunk://#diff-78dbe920496245969f82b2725fe53b5e08e545e8c7d1d2ad4f09a50d649cca7fL219-R249) [[3]](diffhunk://#diff-78dbe920496245969f82b2725fe53b5e08e545e8c7d1d2ad4f09a50d649cca7fL241-R277)
* [`mint/generic-listing.tsx`](diffhunk://#diff-78dbe920496245969f82b2725fe53b5e08e545e8c7d1d2ad4f09a50d649cca7fR32): Added the `useRouter` hook from `next/navigation` to handle navigation within the `GenericListing` component.

These changes improve the navigation and editing capabilities within the contest and problem pages, and enhance the flexibility of the generic listing component.